### PR TITLE
Fixed cast exception to Int into animation

### DIFF
--- a/lib/src/animation.dart
+++ b/lib/src/animation.dart
@@ -1049,8 +1049,7 @@ class IkConstraintTimeline extends CurveTimeline {
                   alpha
           ..bendDirection = direction == MixDirection.mixOut
               ? constraint.data.bendDirection
-              : frames[frames.length + IkConstraintTimeline.prevBendDirection]
-                  as int;
+              : frames[frames.length + IkConstraintTimeline.prevBendDirection].toInt();
       } else {
         constraint.mix = constraint.mix +
             (frames[frames.length + IkConstraintTimeline.prevMix] -
@@ -1085,7 +1084,7 @@ class IkConstraintTimeline extends CurveTimeline {
                 alpha
         ..bendDirection = direction == MixDirection.mixOut
             ? constraint.data.bendDirection
-            : frames[frame + IkConstraintTimeline.prevBendDirection] as int;
+            : frames[frame + IkConstraintTimeline.prevBendDirection].toInt();
     } else {
       constraint.mix = constraint.mix +
           (mix +


### PR DESCRIPTION
```
E/flutter (27420): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'double' is not a subtype of type 'int' in type cast
E/flutter (27420): #0      IkConstraintTimeline.apply (package:spine_core/src/animation.dart:1087:70)
E/flutter (27420): #1      AnimationState.apply (package:spine_core/src/animation_state.dart:182:25)
E/flutter (27420): #2      SpineComponent.calculateBoundsByAnimation (package:bug_smasher/spine_flame/spine_component.dart:194:11)
E/flutter (27420): #3      SpineComponent.onLoad (package:bug_smasher/spine_flame/spine_component.dart:88:20)
E/flutter (27420): <asynchronous suspension>
E/flutter (27420): 
```